### PR TITLE
Fix delete modal so errors show without redirect

### DIFF
--- a/DangQuangTien_RazorPages/Pages/Category/Delete.cshtml.cs
+++ b/DangQuangTien_RazorPages/Pages/Category/Delete.cshtml.cs
@@ -29,7 +29,7 @@ namespace DangQuangTien_RazorPages.Pages.Category
             return result;
         }
 
-        public async Task<IActionResult> OnPostAsync(short id) 
+        public async Task<IActionResult> OnPostAsync(short id)
         {
             var success = await _svc.DeleteAsync(id);
             if (!success)
@@ -37,6 +37,10 @@ namespace DangQuangTien_RazorPages.Pages.Category
                 ModelState.AddModelError(string.Empty,
                     "Cannot delete: this category is in use.");
                 Category = await _svc.GetByIdAsync(id);
+
+                if (Request.Headers["X-Requested-With"] == "XMLHttpRequest")
+                    return Partial("_DeleteFormPartial", this);
+
                 return Page();
             }
             return RedirectToPage("Index");

--- a/DangQuangTien_RazorPages/wwwroot/js/deletePopup.js
+++ b/DangQuangTien_RazorPages/wwwroot/js/deletePopup.js
@@ -16,3 +16,27 @@ document.addEventListener('click', function (e) {
             modal.show();
         });
 });
+
+// Handle submit inside the modal via AJAX
+document.addEventListener('submit', function (e) {
+    const form = e.target.closest('#deleteModal form');
+    if (!form) return;
+
+    e.preventDefault();
+    const url = form.getAttribute('action');
+    const formData = new FormData(form);
+
+    fetch(url, {
+        method: 'POST',
+        body: formData,
+        headers: { 'X-Requested-With': 'XMLHttpRequest' }
+    }).then(function (r) {
+        if (r.redirected) {
+            window.location = r.url;
+            return;
+        }
+        return r.text().then(function (html) {
+            document.querySelector('#deleteModal .modal-body').innerHTML = html;
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- handle delete failure in delete popup without page redirect
- submit delete form via AJAX so error messages stay in modal

## Testing
- `dotnet test -v n`

------
https://chatgpt.com/codex/tasks/task_e_6868f0217bf0832da852946f8bbda3c9