### PR TITLE
Fix category delete popup

### DIFF
--- a/DangQuangTien_RazorPages/Pages/Category/Delete.cshtml.cs
+++ b/DangQuangTien_RazorPages/Pages/Category/Delete.cshtml.cs
@@ -13,11 +13,13 @@ namespace DangQuangTien_RazorPages.Pages.Category
 
         [BindProperty]
         public CategoryEntity? Category { get; set; }
+        public bool InUse { get; set; }
 
         public async Task<IActionResult> OnGetAsync(short id)
         {
             Category = await _svc.GetByIdAsync(id);
             if (Category == null) return RedirectToPage("Index");
+            InUse = await _svc.IsInUseAsync(id);
             return Page();
         }
 
@@ -37,6 +39,7 @@ namespace DangQuangTien_RazorPages.Pages.Category
                 ModelState.AddModelError(string.Empty,
                     "Cannot delete: this category is in use.");
                 Category = await _svc.GetByIdAsync(id);
+                InUse = await _svc.IsInUseAsync(id);
 
                 if (Request.Headers["X-Requested-With"] == "XMLHttpRequest")
                     return Partial("_DeleteFormPartial", this);

--- a/DangQuangTien_RazorPages/Pages/Category/_DeleteFormPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Category/_DeleteFormPartial.cshtml
@@ -1,16 +1,33 @@
 @model DangQuangTien_RazorPages.Pages.Category.DeleteModel
-<div class="mb-3">
-    <p>Are you sure you want to delete:</p>
+<div data-inuse="@Model.InUse">
+@if (Model.InUse)
+{
+    <div class="alert alert-warning">
+        This category is in use and cannot be deleted.
+    </div>
     <dl class="row">
         <dt class="col-sm-2">Name</dt>
         <dd class="col-sm-10">@Model.Category?.CategoryName</dd>
         <dt class="col-sm-2">Description</dt>
         <dd class="col-sm-10">@Model.Category?.CategoryDesciption</dd>
     </dl>
+}
+else
+{
+    <div class="mb-3">
+        <p>Are you sure you want to delete:</p>
+        <dl class="row">
+            <dt class="col-sm-2">Name</dt>
+            <dd class="col-sm-10">@Model.Category?.CategoryName</dd>
+            <dt class="col-sm-2">Description</dt>
+            <dd class="col-sm-10">@Model.Category?.CategoryDesciption</dd>
+        </dl>
+    </div>
+    <form method="post" asp-page="Delete" asp-route-id="@Model.Category?.CategoryId">
+        <button type="submit" class="btn btn-danger">Delete</button>
+    </form>
+}
 </div>
-<form method="post" asp-page="Delete" asp-route-id="@Model.Category?.CategoryId">
-    <button type="submit" class="btn btn-danger">Delete</button>
-</form>
 @if (!ViewData.ModelState.IsValid)
 {
     <div class="text-danger mt-3">

--- a/DangQuangTien_RazorPages/wwwroot/js/deletePopup.js
+++ b/DangQuangTien_RazorPages/wwwroot/js/deletePopup.js
@@ -12,6 +12,8 @@ document.addEventListener('click', function (e) {
         .then(function (html) {
             const modalEl = document.getElementById('deleteModal');
             modalEl.querySelector('.modal-body').innerHTML = html;
+            const inUse = modalEl.querySelector('[data-inuse]')?.getAttribute('data-inuse') === 'True';
+            modalEl.querySelector('.modal-title').textContent = inUse ? 'Warning' : 'Confirm Delete';
             const modal = new bootstrap.Modal(modalEl);
             modal.show();
         });
@@ -36,7 +38,10 @@ document.addEventListener('submit', function (e) {
             return;
         }
         return r.text().then(function (html) {
-            document.querySelector('#deleteModal .modal-body').innerHTML = html;
+            const modalEl = document.getElementById('deleteModal');
+            modalEl.querySelector('.modal-body').innerHTML = html;
+            const inUse = modalEl.querySelector('[data-inuse]')?.getAttribute('data-inuse') === 'True';
+            modalEl.querySelector('.modal-title').textContent = inUse ? 'Warning' : 'Confirm Delete';
         });
     });
 });

--- a/ServiceLayer/Services/Interfaces/ICategoryService.cs
+++ b/ServiceLayer/Services/Interfaces/ICategoryService.cs
@@ -10,6 +10,7 @@ namespace ServiceLayer.Interfaces
         Task<Category?> GetByIdAsync(short id);
         Task CreateAsync(Category category);
         Task UpdateAsync(Category category);
+        Task<bool> IsInUseAsync(short id);
         Task<bool> DeleteAsync(short id);
     }
 }

--- a/ServiceLayer/Services/Services/CategoryService.cs
+++ b/ServiceLayer/Services/Services/CategoryService.cs
@@ -31,6 +31,9 @@ namespace ServiceLayer.Services
             await _repo.SaveChangesAsync();
         }
 
+        public Task<bool> IsInUseAsync(short id)
+            => _repo.HasArticlesAsync(id);
+
         public async Task<bool> DeleteAsync(short id)
         {
             if (await _repo.HasArticlesAsync(id))


### PR DESCRIPTION
## Summary
- warn users when deleting a category that is still referenced
- expose `IsInUseAsync` on category service
- adjust delete modal title via JS based on whether category is in use

## Testing
- `dotnet build DangQuangTien_Se171443_A02.sln`

------
https://chatgpt.com/codex/tasks/task_e_6868f4980600832d94c1dc498cb7cc98