### PR TITLE
Prevent deleting active category

### DIFF
--- a/DangQuangTien_RazorPages/Pages/Category/Delete.cshtml.cs
+++ b/DangQuangTien_RazorPages/Pages/Category/Delete.cshtml.cs
@@ -18,6 +18,13 @@ namespace DangQuangTien_RazorPages.Pages.Category
         {
             Category = await _svc.GetByIdAsync(id);
             if (Category == null) return RedirectToPage("Index");
+
+            if (await _svc.IsInUseAsync(id))
+            {
+                ModelState.AddModelError(string.Empty,
+                    "Cannot delete: this category is in use.");
+            }
+
             return Page();
         }
 

--- a/DangQuangTien_RazorPages/Pages/Category/_DeleteFormPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Category/_DeleteFormPartial.cshtml
@@ -1,6 +1,10 @@
 @model DangQuangTien_RazorPages.Pages.Category.DeleteModel
 <div class="mb-3">
-    <p>Are you sure you want to delete:</p>
+    <p>
+        @(ViewData.ModelState.IsValid
+            ? "Are you sure you want to delete:" 
+            : "Cannot delete: this category is in use.")
+    </p>
     <dl class="row">
         <dt class="col-sm-2">Name</dt>
         <dd class="col-sm-10">@Model.Category?.CategoryName</dd>
@@ -8,9 +12,12 @@
         <dd class="col-sm-10">@Model.Category?.CategoryDesciption</dd>
     </dl>
 </div>
-<form method="post" asp-page="Delete" asp-route-id="@Model.Category?.CategoryId">
-    <button type="submit" class="btn btn-danger">Delete</button>
-</form>
+@if (ViewData.ModelState.IsValid)
+{
+    <form method="post" asp-page="Delete" asp-route-id="@Model.Category?.CategoryId">
+        <button type="submit" class="btn btn-danger">Delete</button>
+    </form>
+}
 @if (!ViewData.ModelState.IsValid)
 {
     <div class="text-danger mt-3">

--- a/ServiceLayer/Services/Interfaces/ICategoryService.cs
+++ b/ServiceLayer/Services/Interfaces/ICategoryService.cs
@@ -11,5 +11,6 @@ namespace ServiceLayer.Interfaces
         Task CreateAsync(Category category);
         Task UpdateAsync(Category category);
         Task<bool> DeleteAsync(short id);
+        Task<bool> IsInUseAsync(short id);
     }
 }

--- a/ServiceLayer/Services/Services/CategoryService.cs
+++ b/ServiceLayer/Services/Services/CategoryService.cs
@@ -43,5 +43,8 @@ namespace ServiceLayer.Services
             await _repo.SaveChangesAsync();
             return true;
         }
+
+        public Task<bool> IsInUseAsync(short id)
+            => _repo.HasArticlesAsync(id);
     }
 }


### PR DESCRIPTION
## Summary
- add `IsInUseAsync` to `ICategoryService`
- implement `IsInUseAsync` in `CategoryService`
- check if category is in use when showing delete popup
- update delete form partial to hide delete button and show warning when category is in use

## Testing
- `dotnet build DangQuangTien_Se171443_A02.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6868f700c05c832db64e5c32f71ad21d