### PR TITLE
Fix delete popup for categories

### DIFF
--- a/DangQuangTien_RazorPages/Pages/Category/Delete.cshtml.cs
+++ b/DangQuangTien_RazorPages/Pages/Category/Delete.cshtml.cs
@@ -14,12 +14,15 @@ namespace DangQuangTien_RazorPages.Pages.Category
         [BindProperty]
         public CategoryEntity? Category { get; set; }
 
+        public bool IsInUse { get; set; }
+
         public async Task<IActionResult> OnGetAsync(short id)
         {
             Category = await _svc.GetByIdAsync(id);
             if (Category == null) return RedirectToPage("Index");
 
-            if (await _svc.IsInUseAsync(id))
+            IsInUse = await _svc.IsInUseAsync(id);
+            if (IsInUse)
             {
                 ModelState.AddModelError(string.Empty,
                     "Cannot delete: this category is in use.");
@@ -41,6 +44,7 @@ namespace DangQuangTien_RazorPages.Pages.Category
             var success = await _svc.DeleteAsync(id);
             if (!success)
             {
+                IsInUse = true;
                 ModelState.AddModelError(string.Empty,
                     "Cannot delete: this category is in use.");
                 Category = await _svc.GetByIdAsync(id);

--- a/DangQuangTien_RazorPages/Pages/Category/_DeleteFormPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Category/_DeleteFormPartial.cshtml
@@ -1,9 +1,9 @@
 @model DangQuangTien_RazorPages.Pages.Category.DeleteModel
 <div class="mb-3">
     <p>
-        @(ViewData.ModelState.IsValid
-            ? "Are you sure you want to delete:" 
-            : "Cannot delete: this category is in use.")
+        @(Model.IsInUse
+            ? "Cannot delete: this category is in use."
+            : "Are you sure you want to delete:")
     </p>
     <dl class="row">
         <dt class="col-sm-2">Name</dt>
@@ -12,18 +12,15 @@
         <dd class="col-sm-10">@Model.Category?.CategoryDesciption</dd>
     </dl>
 </div>
-@if (ViewData.ModelState.IsValid)
+@if (!Model.IsInUse)
 {
     <form method="post" asp-page="Delete" asp-route-id="@Model.Category?.CategoryId">
         <button type="submit" class="btn btn-danger">Delete</button>
     </form>
 }
-@if (!ViewData.ModelState.IsValid)
+@if (Model.IsInUse)
 {
     <div class="text-danger mt-3">
-        @foreach (var err in ViewData.ModelState[string.Empty].Errors)
-        {
-            <p>@err.ErrorMessage</p>
-        }
+        Cannot delete: this category is in use.
     </div>
 }


### PR DESCRIPTION
## Summary
- track `IsInUse` in the Category delete page model
- hide delete button in partial when a category is in use

## Testing
- `dotnet build DangQuangTien_Se171443_A02.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6868facd1960832d93a84125d7b56bf8