### PR TITLE
Improve category delete modal UX

### DIFF
--- a/DangQuangTien_RazorPages/Pages/Shared/_DeletePopupPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Shared/_DeletePopupPartial.cshtml
@@ -6,7 +6,10 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                <!-- Delete form is loaded here -->
+                <div class="delete-form">
+                    <!-- Delete form is loaded here -->
+                </div>
+                <div class="text-danger modal-error mt-2 d-none"></div>
             </div>
         </div>
     </div>

--- a/DangQuangTien_RazorPages/wwwroot/js/deletePopup.js
+++ b/DangQuangTien_RazorPages/wwwroot/js/deletePopup.js
@@ -11,7 +11,12 @@ document.addEventListener('click', function (e) {
         .then(function (r) { return r.text(); })
         .then(function (html) {
             const modalEl = document.getElementById('deleteModal');
-            modalEl.querySelector('.modal-body').innerHTML = html;
+            modalEl.querySelector('.delete-form').innerHTML = html;
+            const errorEl = modalEl.querySelector('.modal-error');
+            if (errorEl) {
+                errorEl.textContent = '';
+                errorEl.classList.add('d-none');
+            }
             const modal = new bootstrap.Modal(modalEl);
             modal.show();
         });
@@ -39,15 +44,18 @@ document.addEventListener('submit', function (e) {
         const contentType = r.headers.get('Content-Type') || '';
         if (contentType.indexOf('application/json') !== -1) {
             r.json().then(function (data) {
-                alert(data.error);
-                const modal = bootstrap.Modal.getInstance(document.getElementById('deleteModal'));
-                if (modal) modal.hide();
+                const modalEl = document.getElementById('deleteModal');
+                const errorEl = modalEl.querySelector('.modal-error');
+                if (errorEl) {
+                    errorEl.textContent = data.error;
+                    errorEl.classList.remove('d-none');
+                }
             });
             return;
         }
 
         r.text().then(function (html) {
-            document.querySelector('#deleteModal .modal-body').innerHTML = html;
+            document.querySelector('#deleteModal .delete-form').innerHTML = html;
         });
     });
 });


### PR DESCRIPTION
## Summary
- keep delete modal open on failure
- show error inline when category deletion fails

## Testing
- `dotnet test`
- `dotnet build DangQuangTien_Se171443_A02.sln`


------
https://chatgpt.com/codex/tasks/task_e_68691f7694b0832da9c03b50d9083b90