### PR TITLE
Normalize encoding for service layer

### DIFF
--- a/ServiceLayer/DTOs/AdminAccountSettings.cs
+++ b/ServiceLayer/DTOs/AdminAccountSettings.cs
@@ -1,4 +1,4 @@
-﻿
+
 
 namespace ServiceLayer.DTOs
 {

--- a/ServiceLayer/Services/Interfaces/IAccountService.cs
+++ b/ServiceLayer/Services/Interfaces/IAccountService.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using DAL.Entities;
 
 namespace ServiceLayer.Interfaces

--- a/ServiceLayer/Services/Interfaces/ICategoryService.cs
+++ b/ServiceLayer/Services/Interfaces/ICategoryService.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using DAL.Entities;
 

--- a/ServiceLayer/Services/Interfaces/INewsService.cs
+++ b/ServiceLayer/Services/Interfaces/INewsService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using DAL.Entities;

--- a/ServiceLayer/Services/Services/AccountService.cs
+++ b/ServiceLayer/Services/Services/AccountService.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using DAL.Entities;
 using DAL.Repositories;

--- a/ServiceLayer/Services/Services/CategoryService.cs
+++ b/ServiceLayer/Services/Services/CategoryService.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using DAL.Entities;
 using DAL.Repositories;

--- a/ServiceLayer/Services/Services/NewsService.cs
+++ b/ServiceLayer/Services/Services/NewsService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;


### PR DESCRIPTION
## Summary
- remove BOM markers in ServiceLayer DTOs and service classes
- ensure UTF-8 without BOM

## Testing
- `dotnet test DangQuangTien_Se171443_A02.sln`

------
https://chatgpt.com/codex/tasks/task_e_6869371ed754832da2885a0e794a9256